### PR TITLE
Add vite-plus env setup to zsh config

### DIFF
--- a/nix/darwin-home/home.nix
+++ b/nix/darwin-home/home.nix
@@ -229,6 +229,8 @@
       [ -s "/opt/homebrew/opt/nvm/etc/bash_completion.d/nvm" ] && \. "/opt/homebrew/opt/nvm/etc/bash_completion.d/nvm"  # This loads nvm bash_completion
 
       export ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE='fg=5'; # Fix tmux suggestion color
+
+      . "$HOME/.vite-plus/env"
     '' + builtins.readFile ./configs/.p10k.zsh;
   };
 }


### PR DESCRIPTION
Sources `~/.vite-plus/env` in the zsh `initExtra` block so vite-plus is initialized on shell startup.